### PR TITLE
DATE PICKER Remove duplicate init call

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -52,7 +52,6 @@ function initAll(scope = document) {
 
     const datePickers = [].slice.call(document.querySelectorAll('[data-module="ds-datepicker"]'));
     datePickers.forEach(datePicker => new DSDatePicker(datePicker).init());
-    datePickers.forEach(datePicker => new DSDatePicker(datePicker).init());
 
     // this one is handled differently because it applies an event to the whole body and we only want that event once
     const hidePageButtons = [].slice.call(scope.querySelectorAll('.ds_hide-page'));


### PR DESCRIPTION
Removed duplicate inii call of date picker. In some cases, this doubles the number of buttons rendered.

Here is an example [stackblitz](https://stackblitz.com/edit/angular-ivy-jzeszs?file=src%2Fapp%2Fapp.component.html)