### PR TITLE
Current navigation link styling

### DIFF
--- a/src/base/helpers/fancy-underscore/_fancy-underscore.scss
+++ b/src/base/helpers/fancy-underscore/_fancy-underscore.scss
@@ -25,6 +25,7 @@
         transition: left $transition-in-time, right $transition-in-time, opacity $transition-in-time;
     }
 
+    &.ds_current::after,
     &:hover::after {
         left: 0;
         opacity: 1;

--- a/src/components/site-navigation/_site-navigation.scss
+++ b/src/components/site-navigation/_site-navigation.scss
@@ -114,20 +114,10 @@ $site-navigation__link-padding: 16px;
         }
 
         &__link {
-            &.ds_current {
-                //background-color: $ds_colour__link--current__background;
-                color: $ds_colour__text;
-                //outline: 1px solid $ds_colour__border--light;
-                //outline-offset: 0px;
-            }
-        }
-
-        a.ds_site-navigation__link {
-            @include ds_fancy-underscore;
+            @include ds_fancy-underscore(3px);
 
             &::after {
                 bottom: 0;
-                height: 3px;
             }
 
             &:focus {
@@ -140,6 +130,7 @@ $site-navigation__link-padding: 16px;
                 }
             }
 
+            &.ds_current:not(:focus),
             &:hover:not(:focus) {
                 background-color: $ds_colour__link--hover__background;
             }


### PR DESCRIPTION
Implementation of `ds_current` styling for site navigation links.

<img width="674" alt="navigation-current" src="https://user-images.githubusercontent.com/1349297/133098122-c1f138f0-70c7-48b5-b771-4f1bd46765a2.png">
