### PR TITLE
DS-433 GitHub workflow updates

### DIFF
--- a/.github/workflows/npm-publish-only.yml
+++ b/.github/workflows/npm-publish-only.yml
@@ -1,0 +1,34 @@
+name: npm publish only
+
+on:
+  workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Set up node and add the registry url
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+          always-auth: true
+
+      # Install
+      - name: Install
+        run: npm ci
+
+      # Test
+      - name: Run tests
+        run: npm run test
+
+      # Publish to npm
+      - name: Publish npm package
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,4 +1,4 @@
-name: Publish package to npm
+name: Versioned release
 
 on:
   workflow_dispatch:
@@ -11,10 +11,10 @@ on:
           - patch
           - minor
           - major
-          # - prepatch
-          # - preminor
-          # - premajor
-          # - prerelease
+          - prepatch
+          - preminor
+          - premajor
+          - prerelease
 
 jobs:
   build:
@@ -55,6 +55,15 @@ jobs:
         env:
           RELEASE_TYPE: ${{github.event.inputs.release_type}}
 
+      # Set pre-release version
+      - name: Set pre-release version
+        if: startsWith(github.event.inputs.release_type, 'pre')
+        run: |
+          echo "NEW_VERSION=$(npm --no-git-tag-version --preid=beta version $RELEASE_TYPE)" >> $GITHUB_ENV
+          echo "RELEASE_TAG=beta" >> $GITHUB_ENV
+        env:
+          RELEASE_TYPE: ${{github.event.inputs.release_type}}
+
       # Set version in DS code
       - name: Set version in DS
         run: |
@@ -69,15 +78,15 @@ jobs:
           git commit -m "chore: release ${{env.NEW_VERSION}}"
           git tag ${{env.NEW_VERSION}}
 
-      # Publish to npm
-      - name: Publish npm package
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-
       # Push to git repo
       - name: Push changes to git
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           git push origin && git push --tags
+
+      # Publish to npm
+      - name: Publish npm package
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
- New workflow “npm publish only”: runs unit tests and does npm publish. To be used only when a npm publish fails in the larger workflow job once the reason for the failure has been corrected.
- Rename the “Publish package to npm” workflow to “Versioned release” so it’s clearer how it differs from the new one.
- Edit “Versioned release” to include the prerelease numbering and move the npm publish step to the end.