### PR TITLE
DS-523 Site branding line height fix

### DIFF
--- a/src/components/site-branding/_site-branding.scss
+++ b/src/components/site-branding/_site-branding.scss
@@ -56,6 +56,7 @@ $site-branding-title-spacing--medium: 48px;
     &__title {
         float: left;
     }
+
 }
 
 @include ds_media-query (medium) {
@@ -74,7 +75,6 @@ $site-branding-title-spacing--medium: 48px;
         }
 
         &__title {
-            line-height: $site-logo__height--medium;
 
             &::before {
                 margin-left: px-to-rem($site-branding-title-spacing--medium * -0.5);


### PR DESCRIPTION
Fix issue on larger viewports where site branding title had a fixed height to match the height of the logo. This caused issues when the text spanned more than one line.