### PR TITLE
dsp-766 Remove unused ds_reversed site search styles

### DIFF
--- a/src/components/site-search/_site-search.scss
+++ b/src/components/site-search/_site-search.scss
@@ -43,9 +43,3 @@ $site-search__border-colour: $ds_colour__grey !default;
         }
     }
 }
-
-.ds_reversed .ds_site-search {
-    .ds_site-search__button {
-        background-color: $ds_colour__brand--secondary;
-    }
-}


### PR DESCRIPTION
It doesn't appear to be used and combined with changing the sequential navigation component to use text colour it limits our current use of the secondary brand colour to just the gradient background option on site header