### PR TITLE
dsp-848 fix links styled like button text not vertically centred when…

### DIFF
--- a/src/components/button/_button-group.scss
+++ b/src/components/button/_button-group.scss
@@ -12,6 +12,7 @@
 
     // Remove margins as the group handles the layout
     .ds_button {
+        align-content: center;
         margin: 0;
     }
 


### PR DESCRIPTION
… in button group

This happens when other buttons make the height of the button group taller than default