### PR TITLE
DSP-857 Images in Aspect Box are not sized correctly in ds_layout__content

### DIFF
--- a/src/base/objects/layout/_layout.scss
+++ b/src/base/objects/layout/_layout.scss
@@ -9,7 +9,6 @@
     &__content,
     &__partner {
         img {
-            height: auto;
             max-width: 100%;
         }
     }
@@ -97,7 +96,7 @@
             }
         }
 
-        // .ds_layout--search-results-with-sidebar is deprecated - this will be removed in a future release 
+        // .ds_layout--search-results-with-sidebar is deprecated - this will be removed in a future release
         &--search-results-with-sidebar {
             .ds_layout {
 
@@ -287,7 +286,7 @@
                 'f f';
         }
 
-        // .ds_layout--search-results-with-sidebar is deprecated - this will be removed in a future release 
+        // .ds_layout--search-results-with-sidebar is deprecated - this will be removed in a future release
         &--search-results-with-sidebar {
             grid-template-areas:
                 'h h'
@@ -359,7 +358,7 @@
                     'f f f f f f';
             }
 
-            // .ds_layout--search-results-with-sidebar is deprecated - this will be removed in a future release 
+            // .ds_layout--search-results-with-sidebar is deprecated - this will be removed in a future release
             &--search-results-with-sidebar {
                 grid-template-areas:
                     'h h h h h h'
@@ -434,7 +433,7 @@
                     '. . . . f f f f f f f f';
             }
 
-            // .ds_layout--search-results-with-sidebar is deprecated - this will be removed in a future release 
+            // .ds_layout--search-results-with-sidebar is deprecated - this will be removed in a future release
             &--search-results-with-sidebar {
                 grid-template-areas:
                     'h h h h h h h h . . . .'


### PR DESCRIPTION
It's safe to remove the 'height: auto' from .ds_layout__content img