### PR TITLE
Add Now Prototype It configurations for easier prototyping

### DIFF
--- a/now-prototype-it.config.json
+++ b/now-prototype-it.config.json
@@ -1,0 +1,45 @@
+{
+  "version-2024-03": {
+    "meta": {
+      "description": "Scottish Government Design System plugin for the GOV.UK Prototype Kit"
+    },
+    "assets": [
+      "/dist/images/"
+    ],
+    "nunjucksPaths": [
+      "/"
+    ],
+    "sass": [
+      "/src/design-system.scss"
+    ],
+    "scripts": [
+      "/dist/scripts/design-system.js"
+    ],
+    "relatedPlugins": {
+      "fromNpm": [
+        "@scottish-government-design-system/prototype-templates"
+      ]
+    },
+    "settings": [
+      {
+        "value": "{{PLUGIN_SPECIFIC_SETTINGS_PAGE_URL}}",
+        "variableNames": {
+          "nunjucks": "scotgovDesignSystem.settingsPageUrl"
+        }
+      },
+      {
+        "value": "Service name goes here",
+        "isDefault": true,
+        "variableNames": {
+          "nunjucks": "serviceName"
+        },
+        "userInterface": {
+          "key": "serviceName",
+          "name": "Service name",
+          "hintText": "This is used in the header of each page by default. You can override this in individual templates.",
+          "type": "string"
+        }
+      }
+    ]
+  }
+}

--- a/now-prototype-it.variant.json
+++ b/now-prototype-it.variant.json
@@ -1,0 +1,13 @@
+{
+  "version-2024-03": {
+    "inheritFrom": ["nowprototypeit"],
+    "installedPackages": [
+      "__INHERIT__",
+      "@scottish-government-design-system/prototype-templates"
+    ],
+    "starterFileDirectories": [
+      "__INHERIT__",
+      "/src/prototype-tools/starter-files"
+    ]
+  }
+}

--- a/src/prototype-tools/starter-files/app/views/index.njk
+++ b/src/prototype-tools/starter-files/app/views/index.njk
@@ -1,0 +1,42 @@
+{% extends "sg-prototype-templates/layouts/_base-layout.njk" %}
+
+{% block pageTitle %}Scottish Government Prototype Kit{% endblock %}
+
+{% block siteBrandingTitle %}
+  <div class="ds_site-branding__title">
+    {{ serviceName }}
+  </div>
+{% endblock %}
+
+{% block siteSearch %}{% endblock %}
+{% block breadcrumbs %}{% endblock %}
+
+{% block main %}
+  <div class="ds_wrapper">
+    <main id="main-content" class="ds_layout  ds_layout--article">
+
+      {% block mainHeader %}
+        <div class="ds_layout__header">
+          <header class="ds_page-header">
+            <h1 class="ds_page-header__title">Scottish Government Prototype Kit</h1>
+          </header>
+        </div>
+      {% endblock %}
+
+      {% block mainContent %}
+        {% include "prototype-core/includes/homepage-top.njk" %}
+        <div class="ds_layout__content">
+
+          {% if scotgovDesignSystem.settingsPageUrl and "/manage-prototype" in scotgovDesignSystem.settingsPageUrl %}
+            <p>
+              You can change your service name in the <a href="{{ scotgovDesignSystem.settingsPageUrl }}">Plugin-specific configuration</a>.
+            </p>
+          {% endif %}
+          {% include "prototype-core/includes/homepage-bottom.njk" %}
+
+        </div>
+      {% endblock %}
+
+    </main>
+  </div>
+{% endblock %}


### PR DESCRIPTION
The current [instructions for "HTML prototyping"](https://github.com/scottish-government-design-system/prototype-templates?tab=readme-ov-file#how-to-install-the-scottish-government-design-system-prototype-templates-plugin) require a number of steps, this is expected when adapting a tool beyond the use-case which it was designed for.

This Pull Request takes the tools you've already built and sets them up for easy installation with Now Prototype It.

Now Prototype It is an open source (MIT Licence) Prototype Kit based on the GOV.UK Prototype Kit, we have removed previously hard-coded GOV.UK references and improved the Plugin Framework to create a smoother integration.  The goal is to make sure that a wider range of UK Government organisations can share a prototyping tool regardless of whether or not they use GOV.UK Frontend.  Now Prototype It by itself is not targeted towards any one design system and is suitable for use both inside and outside UK Government, we took this approach because we believe will bring even more features to a whole range of users.

This Pull Request adds a `now-prototype-it.config.json`, which is used to configure:

 - Settings - this includes the Service Name which can be changed by the user in the UI
 - Related Plugins - this powers the plugin list, any plugin can include related plugins which make it easy for users to discover

This Pull Request also includes a `now-prototype-it.variant.json` which can be used to create a Scot.gov style prototype with a single command.  This will include:

 - Pre-installing the design system and templates plugin
 - Creating a homepage which welcomes the user

If these changes are merged and released then users will be able to create a prototype by running:

```
npx nowprototypeit create --variant=@scottish-government/design-system the-name-of-your-prototype
```

This will install the `@scottish-government/design-system` package from NPM, customising the user's prototype based on the variant file.  To test the behaviour without merging/releasing you can use the command:

```
npx nowprototypeit create --variant=@scottish-government/design-system --variant-dependency=github:nataliecarey/scot-gov-design-system#now-prototype-it-config the-name-of-your-prototype
```

There are lots of other options you could consider adding to this integration, I'd be very happy to give a demo and help to work on the integration.

For more general information on Now Prototype It you can check out [our website nowprototype.it](https://nowprototype.it/) and [our youtube channel](https://www.youtube.com/@now-prototype-it/videos).