### PR TITLE
DSP-1145 Accessibility improvements for accordions

### DIFF
--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -61,13 +61,15 @@ class Accordion {
 
         itemButton.innerHTML = itemTitle.innerHTML;
 
+        itemIndicator.setAttribute('aria-hidden', true);
+
         itemTitle.innerHTML = '';
         itemTitle.insertBefore(itemButton, itemTitle.firstChild);
         itemButton.appendChild(itemIndicator);
         itemLabelContent.classList.add('fully-hidden');
 
-        itemBody.id = itemBody.id || `accordion-item-${elementIdModifier()}`;
-        itemButton.setAttribute('aria-controls', itemBody.id);
+        item.id = item.id || `accordion-item-${elementIdModifier()}`;
+        itemBody.id = itemBody.id || `accordion-item-${elementIdModifier()}-body`;
 
         if (startsOpen) {
             item.classList.add('ds_accordion-item--open');
@@ -117,6 +119,9 @@ class Accordion {
 
             this.setOpenAllButton(opening);
         });
+
+        this.openAllButton.setAttribute('aria-controls', this.items.map(item => item.id).join(' '));
+        this.openAllButton.setAttribute('aria-expanded', false);
     }
 
     toggleAccordionItem(item) {
@@ -144,6 +149,7 @@ class Accordion {
         } else {
             this.openAllButton.innerHTML = 'Open all <span class="visually-hidden">sections</span>';
         }
+        this.openAllButton.setAttribute('aria-expanded', open)
     }
 
     checkAllOpen() {


### PR DESCRIPTION
- add "aria-hidden" to the indicator element to prevent it duplicating/conflicting with information provided by aria-expanded
- add "aria-expanded" to the "open all" button, which toggles to true when all items are open
- add "aria-controls" to the "open all" button, whose value is a space-separated list of all of the accordion items' IDs