### PR TITLE
Button style updates

### DIFF
--- a/src/base/settings/colours/_colours.scss
+++ b/src/base/settings/colours/_colours.scss
@@ -123,7 +123,8 @@ $ds_colour__button--secondary--focus:               $ds_colour__button--focus !d
 $ds_colour__button--cancel:                         $ds_colour__text !default;
 $ds_colour__button--cancel__background:             $ds_colour__button--secondary__background !default;
 $ds_colour__button--cancel--hover__background:      adjustLuminance($ds_colour__button--cancel, 0.83) !default; /// [1]
-$ds_colour__button--disabled__background:           $ds_colour__grey !default;
+$ds_colour__button--disabled:                       $ds_colour__text !default;
+$ds_colour__button--disabled__background:           $ds_colour__grey--medium !default;
 
 
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -64,7 +64,7 @@ $link__border-width: 0.16em !default;
     &[disabled] {
         background-color: $ds_colour__button--disabled__background;
         box-shadow: none;
-        color: $ds_colour__button;
+        color: $ds_colour__button--disabled;
         font-weight: $normal;
         outline: none;
         pointer-events: none;
@@ -112,18 +112,9 @@ $link__border-width: 0.16em !default;
         }
     }
 
+    // .ds_button--cancel is deprecated - this will be removed in a future release
     &--cancel {
-        background-color: $ds_colour__button--cancel__background;
-        color: $ds_colour__button--cancel;
-        outline: 2px solid currentColor;
-        outline-offset: -2px;
-
-        &:hover:not(:focus) {
-            background-color: $ds_colour__button--cancel--hover__background;
-            color: $ds_colour__button--cancel;
-            outline: 2px solid currentColor;
-            outline-offset: -2px;
-        }
+        @extend .ds_button--secondary;
     }
 }
 


### PR DESCRIPTION
DSP-969 Update to disabled button colours
DSP-998 Remove 'cancel' button style
- 'cancel' button retained as a CSS class but with identical appearance to 'secondary' button