### PR TITLE
DSP-1319 Tabs improvements to bring it in line with W3C APG recommendations

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -9,6 +9,8 @@ class Tabs {
         this.resizeTimer = null;
         this.eventsEnabled = false;
 
+        this.automaticActivation = !tabContainer.classList.contains('ds_tabs--manual');
+
         this.tabContainer = tabContainer;
         // The list containing the tabs
         this.tabList = tabContainer.querySelector('.ds_tabs__list');
@@ -18,10 +20,11 @@ class Tabs {
         this.tabContents = [].slice.call(tabContainer.querySelectorAll('.ds_tabs__content'));
 
         this.keycodes = {
+            'space': 32,
+            'end': 35,
+            'home': 36,
             'left': 37,
-            'up': 38,
-            'right': 39,
-            'down': 40
+            'right': 39
         };
 
         // Handle hashchange events
@@ -39,10 +42,15 @@ class Tabs {
             this.tabList.setAttribute('role', 'tablist');
             this.tabHeaders.forEach((tabHeader, index) => this.initTab(tabHeader, index));
 
+            this.tabContents.forEach(item => {
+                item.setAttribute('tabindex', '0')
+                item.setAttribute('role', 'tabpanel');
+            });
+
             // Set the active tab based on the URL's hash or the first tab
             let currentTabLink = this.getTab(window.location.hash) || this.tabHeaders[0].querySelector('.ds_tabs__tab-link');
             let currentTab = currentTabLink.parentElement;
-            this.activateTab(currentTab);
+            this.goToTab(currentTab);
 
             // Mark as initialised for specific layout support
             this.tabContainer.classList.add('js-initialised');
@@ -66,6 +74,10 @@ class Tabs {
             this.tabList.removeAttribute('role');
             this.tabHeaders.forEach((tabHeader, index) => this.resetTab(tabHeader, index));
 
+            this.tabContents.forEach(item => {
+                item.removeAttribute('tabindex');
+                item.removeAttribute('role');
+            });
         }
     }
 
@@ -85,20 +97,13 @@ class Tabs {
     onHashChange() {
         let tabWithHashLink = this.getTab(window.location.hash);
         if (!tabWithHashLink) {
-          return;
+            return;
         }
+
         let tabWithHash = tabWithHashLink.parentElement;
 
-        // Prevent changing the hash
-        if (this.changingHash) {
-          this.changingHash = false;
-          return;
-        }
-
         if (breakpointCheck('medium')) {
-            let currentTab = this.getCurrentTab();
-            this.deactivateTab(currentTab);
-            this.activateTab(tabWithHash);
+            this.goToTab(tabWithHash);
             tabWithHash.querySelector('.ds_tabs__tab-link').focus();
         }
     }
@@ -106,8 +111,7 @@ class Tabs {
     // Add the specified tab to the browser history
     createHistoryEntry(tab) {
         let tabId = this.getHref(tab);
-        this.changingHash = true;
-        window.location.hash = tabId;
+        history.pushState(null,null,tabId);
     }
 
     // Reset tab back to original state
@@ -117,7 +121,6 @@ class Tabs {
 
         const tabLink = tabHeader.querySelector('.ds_tabs__tab-link');
         const tabContent = this.tabContents[index];
-        const tabId = tabContent.getAttribute('id');
 
         tabLink.removeAttribute('role');
         tabLink.removeAttribute('aria-controls');
@@ -144,65 +147,70 @@ class Tabs {
 
         // Only set event listeners on initial setup
         if(!this.eventsEnabled){
-            tabLink.addEventListener('click', () => {
-                if (breakpointCheck('medium')) {
-                    let currentTab = this.getCurrentTab();
-                    this.deactivateTab(currentTab);
-                    this.activateTab(tabHeader);
-                }
+            tabLink.addEventListener('click', event => {
+                event.preventDefault();
+                this.goToTab(tabHeader);
             });
 
             tabLink.addEventListener('keydown', (event) => {
+                const tab = event.target.parentElement;
                 let tabNavKey = true;
 
-                if (breakpointCheck('medium')) {
-                    if (event.keyCode === this.keycodes.right) {
-                        this.activateNextTab(event);
-                    } else if (event.keyCode === this.keycodes.left) {
-                        this.activatePreviousTab(event);
-                    } else if (event.keyCode === this.keycodes.up) {
-                        this.activatePreviousTab(event);
-                    } else if (event.keyCode === this.keycodes.down) {
-                        this.activateNextTab(event);
-                    } else {
-                        tabNavKey = false;
-                    }
+                if (event.keyCode === this.keycodes.right) {
+                    this.navToTab(this.getNextTab(tab));
+                } else if (event.keyCode === this.keycodes.left) {
+                    this.navToTab(this.getPreviousTab(tab));
+                } else if (event.keyCode === this.keycodes.home) {
+                    this.navToTab(this.getFirstTab());
+                } else if (event.keyCode === this.keycodes.end) {
+                    this.navToTab(this.getLastTab());
+                } else if (event.keyCode === this.keycodes.space) {
+                    this.goToTab(tab, true)
+                } else {
+                    tabNavKey = false;
+                }
 
-                    if (tabNavKey) {
-                        event.preventDefault();
-                        event.stopPropagation();
-                    }
+                if (tabNavKey) {
+                    event.preventDefault();
                 }
             });
         }
     }
 
-    // Activate next tab from the current selected tab
-    activateNextTab() {
-        let currentTab = this.getCurrentTab();
-        let nextTab = currentTab.nextElementSibling;
-        if (nextTab){
-            this.deactivateTab(currentTab);
-            this.activateTab(nextTab);
-            this.createHistoryEntry(nextTab);
-            nextTab.querySelector('.ds_tabs__tab-link').focus();
+    navToTab(tab) {
+        // first, focus the tab
+        tab.querySelector('.ds_tabs__tab-link').focus();
+
+        // then navigate
+        if (this.automaticActivation) {
+            this.goToTab(tab);
         }
     }
 
-    // Activate previous tab from the current selected tab
-    activatePreviousTab() {
-        let currentTab = this.getCurrentTab();
-        let previousTab = currentTab.previousElementSibling;
-        if (previousTab){
-            this.deactivateTab(currentTab);
-            this.activateTab(previousTab);
-            this.createHistoryEntry(previousTab);
-            previousTab.querySelector('.ds_tabs__tab-link').focus();
-        }
+    getNextTab(currentTab) {
+        return currentTab.nextElementSibling || this.getFirstTab();
     }
 
-    // Activate specified tab
-    activateTab(targetTab) {
+    getPreviousTab(currentTab) {
+        return currentTab.previousElementSibling || this.getLastTab();
+    }
+
+    getFirstTab() {
+        return this.tabHeaders[0];
+    }
+
+    getLastTab() {
+        return this.tabHeaders[this.tabHeaders.length - 1];
+    }
+
+    // Go to specified tab
+    goToTab(targetTab) {
+        let oldTab = this.getCurrentTab();
+
+        if (oldTab === targetTab) {
+            return;
+        }
+
         let targetTabLink = targetTab.querySelector('.ds_tabs__tab-link');
         let targetTabContent = this.getTabContent(targetTab);
 
@@ -212,6 +220,9 @@ class Tabs {
 
         // Show content for tab
         targetTabContent.classList.remove('ds_tabs__content--hidden');
+
+        this.deactivateTab(oldTab);
+        this.createHistoryEntry(targetTab);
     }
 
     // Deactivate specified tab

--- a/src/components/tabs/tabs.test.js
+++ b/src/components/tabs/tabs.test.js
@@ -110,6 +110,7 @@ describe('tabs', () => {
             testObj.tabsModule.init();
 
             const tabItems = testObj.tabsElement.querySelectorAll('.ds_tabs__tab');
+            const tabContents = testObj.tabsElement.querySelectorAll('.ds_tabs__content');
 
             for (let i = 0, il = tabItems.length; i < il; i++) {
                 expect(tabItems[i].getAttribute('role')).toEqual('presentation');
@@ -125,9 +126,12 @@ describe('tabs', () => {
                     expect(tabLink.getAttribute('aria-selected')).toEqual('false');
                     expect(tabLink.getAttribute('tabindex')).toEqual('-1');
                 }
-
             }
 
+            for (let i = 0, il = tabContents.length; i < il; i++) {
+                expect(tabContents[i].getAttribute('role')).toEqual('tabpanel');
+                expect(tabContents[i].getAttribute('tabindex')).toEqual('0');
+            }
         });
 
         it ('should have attributes removed on reset', () => {
@@ -135,6 +139,7 @@ describe('tabs', () => {
             testObj.tabsModule.reset();
 
             const tabItems = testObj.tabsElement.querySelectorAll('.ds_tabs__tab');
+            const tabContents = testObj.tabsElement.querySelectorAll('.ds_tabs__content');
 
             for (let i = 0, il = tabItems.length; i < il; i++) {
                 expect(tabItems[i].hasAttribute('role')).toBeFalsy();
@@ -144,14 +149,17 @@ describe('tabs', () => {
                 expect(tabLink.hasAttribute('aria-controls')).toBeFalsy();
                 expect(tabLink.hasAttribute('aria-selected')).toBeFalsy();
                 expect(tabLink.hasAttribute('tabindex')).toBeFalsy();
+            }
 
+            for (let i = 0, il = tabContents.length; i < il; i++) {
+                expect(tabContents[i].hasAttribute('role')).toBeFalsy();
+                expect(tabContents[i].hasAttribute('tabindex')).toBeFalsy();
             }
         });
 
         it ('should show specified tab on init if hash present', () => {
             window.location.hash = '#tab2';
             testObj.tabsModule.init();
-
             // Is initialised
             expect(testObj.tabsElement.classList.contains('js-initialised')).toBe(true);
 
@@ -168,7 +176,7 @@ describe('tabs', () => {
             let currentTabItem = testObj.tabsElement.querySelector('.ds_current');
             expect(currentTabItem.querySelector('.ds_tabs__tab-link').getAttribute('href')).toBe('#tab1');
 
-            // Change hash
+            // // Change hash
             window.location.hash = '#tab2';
             const event = new Event('hashchange');
             window.dispatchEvent(event);
@@ -245,38 +253,20 @@ describe('tabs', () => {
             expect(currentTabLink.getAttribute('href')).toBe('#tab1');
         });
 
-        it ('should change to previous tab on up arrow key press', () => {
-            // Set second tab to be the selected one
-            window.location.hash = '#tab2';
-            testObj.tabsModule.init();
-
-            let currentTab = testObj.tabsElement.querySelector('.ds_current');
-            let currentTabLink = currentTab.querySelector('.ds_tabs__tab-link');
-            expect(currentTabLink.getAttribute('href')).toBe('#tab2');
-
-            // Press on up arrow key from second tab
-            const event = new KeyboardEvent( 'keydown' , {'keyCode':38} );
-            currentTabLink.dispatchEvent(event);
-
-            currentTab = testObj.tabsElement.querySelector('.ds_current');
-            currentTabLink = currentTab.querySelector('.ds_tabs__tab-link');
-            expect(currentTabLink.getAttribute('href')).toBe('#tab1');
-        });
-
-        it ('should remain on first tab on up arrow key press', () => {
+        it ('should go to last tab from first tab on left key press', () => {
             testObj.tabsModule.init();
 
             let currentTab = testObj.tabsElement.querySelector('.ds_current');
             let currentTabLink = currentTab.querySelector('.ds_tabs__tab-link');
             expect(currentTabLink.getAttribute('href')).toBe('#tab1');
 
-            // Press on up arrow key from second tab
-            const event = new KeyboardEvent( 'keydown' , {'keyCode':38} );
+            // Press on left arrow key from first tab
+            const event = new KeyboardEvent( 'keydown' , {'keyCode':37} );
             currentTabLink.dispatchEvent(event);
 
             currentTab = testObj.tabsElement.querySelector('.ds_current');
             currentTabLink = currentTab.querySelector('.ds_tabs__tab-link');
-            expect(currentTabLink.getAttribute('href')).toBe('#tab1');
+            expect(currentTabLink.getAttribute('href')).toBe('#tab4');
         });
 
         it ('should change to next tab on right arrow key press', () => {
@@ -295,24 +285,7 @@ describe('tabs', () => {
             expect(currentTabLink.getAttribute('href')).toBe('#tab2');
         });
 
-        it ('should change to next tab on down arrow key press', () => {
-            testObj.tabsModule.init();
-
-            let currentTab = testObj.tabsElement.querySelector('.ds_current');
-            let currentTabLink = currentTab.querySelector('.ds_tabs__tab-link');
-            expect(currentTabLink.getAttribute('href')).toBe('#tab1');
-
-            // Press on down arrow key from first tab
-            const event = new KeyboardEvent( 'keydown' , {'keyCode':40} );
-            currentTabLink.dispatchEvent(event);
-
-            currentTab = testObj.tabsElement.querySelector('.ds_current');
-            currentTabLink = currentTab.querySelector('.ds_tabs__tab-link');
-            expect(currentTabLink.getAttribute('href')).toBe('#tab2');
-        });
-
-        it ('should remain on last tab on down arrow key press', () => {
-            // Set last tab to be the selected one
+        it('should go to first tab from last tab on right key press', () => {
             window.location.hash = '#tab4';
             testObj.tabsModule.init();
 
@@ -320,13 +293,47 @@ describe('tabs', () => {
             let currentTabLink = currentTab.querySelector('.ds_tabs__tab-link');
             expect(currentTabLink.getAttribute('href')).toBe('#tab4');
 
-            // Press on down arrow key from first tab
-            const event = new KeyboardEvent( 'keydown' , {'keyCode':40} );
+            // Press on left arrow key from first tab
+            const event = new KeyboardEvent( 'keydown' , {'keyCode':39} );
+            currentTabLink.dispatchEvent(event);
+
+            currentTab = testObj.tabsElement.querySelector('.ds_current');
+            currentTabLink = currentTab.querySelector('.ds_tabs__tab-link');
+            expect(currentTabLink.getAttribute('href')).toBe('#tab1');
+        });
+
+        it ('should change to last tab on End key press', () => {
+            testObj.tabsModule.init();
+
+            let currentTab = testObj.tabsElement.querySelector('.ds_current');
+            let currentTabLink = currentTab.querySelector('.ds_tabs__tab-link');
+            expect(currentTabLink.getAttribute('href')).toBe('#tab1');
+
+            // Press on End key from first tab
+            const event = new KeyboardEvent( 'keydown' , {'keyCode':35} );
             currentTabLink.dispatchEvent(event);
 
             currentTab = testObj.tabsElement.querySelector('.ds_current');
             currentTabLink = currentTab.querySelector('.ds_tabs__tab-link');
             expect(currentTabLink.getAttribute('href')).toBe('#tab4');
+        });
+
+        it ('should change to first tab on Home key press', () => {
+            // Set second tab to be the selected one
+            window.location.hash = '#tab4';
+            testObj.tabsModule.init();
+
+            let currentTab = testObj.tabsElement.querySelector('.ds_current');
+            let currentTabLink = currentTab.querySelector('.ds_tabs__tab-link');
+            expect(currentTabLink.getAttribute('href')).toBe('#tab4');
+
+            // Press on End key from first tab
+            const event = new KeyboardEvent( 'keydown' , {'keyCode':36} );
+            currentTabLink.dispatchEvent(event);
+
+            currentTab = testObj.tabsElement.querySelector('.ds_current');
+            currentTabLink = currentTab.querySelector('.ds_tabs__tab-link');
+            expect(currentTabLink.getAttribute('href')).toBe('#tab1');
         });
 
         it ('should remain on same tab if key pressed is not an arrow key', () => {
@@ -361,8 +368,8 @@ describe('tabs', () => {
             let currentTabLink = currentTab.querySelector('.ds_tabs__tab-link');
             expect(currentTabLink.getAttribute('href')).toBe('#tab1');
 
-            // Press on down arrow key from first tab to change to second tab
-            const event = new KeyboardEvent( 'keydown' , {'keyCode':40} );
+            // Press on right arrow key from first tab to change to second tab
+            const event = new KeyboardEvent( 'keydown' , {'keyCode':39} );
             currentTabLink.dispatchEvent(event);
 
             currentTab = testObj.tabsElement.querySelector('.ds_current');
@@ -384,6 +391,36 @@ describe('tabs', () => {
             // Returns content for selected tab
             expect(currentTabContent.innerHTML).toContain('Tab 4 content');
 
+        });
+    });
+
+    describe('manual activation', () => {
+        beforeEach(() => {
+            testObj.tabsElement = document.querySelector('#tab');
+            testObj.tabsElement.classList.add('ds_tabs--manual');
+            testObj.tabsModule = new Tabs(testObj.tabsElement);
+        });
+
+        it('should not automatically switch tabs on press of left, right, home or end keys', () => {
+            window.location.hash = '#tab1';
+            testObj.tabsModule.init();
+            testObj.tabsModule.init();
+
+            spyOn(testObj.tabsModule, 'goToTab');
+
+            const currentTabLink = testObj.tabsElement.querySelector('.ds_current a');
+
+            // Press on tab key (9) from first tab
+            let event = new KeyboardEvent('keydown', { 'keyCode': 35 });
+            currentTabLink.dispatchEvent(event);
+            event = new KeyboardEvent('keydown', { 'keyCode': 36 });
+            currentTabLink.dispatchEvent(event);
+            event = new KeyboardEvent('keydown', { 'keyCode': 37 });
+            currentTabLink.dispatchEvent(event);
+            event = new KeyboardEvent( 'keydown' , {'keyCode':39} );
+            currentTabLink.dispatchEvent(event);
+
+            expect(testObj.tabsModule.goToTab).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
APG-related changes:
- 'tabpanel' role on tab panels
- 'tabindex=0' on tab panels
- user is not scrolled to tab content on activation of a tab
- keyboard interactions amended. removed up/down, added home/end (first/last tab)

Add option for manual activation, toggled via modifier class on the tab container. Space key can activate a focused tab.