### PR TITLE
DSP-1633 Refactor GitHub workflows as a precursor to using trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,13 +1,18 @@
-name: npm publish only
+name: npm publish
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
+      - if: ${{ github.ref_type != 'tag' }}
+        run: |
+          echo "No tag specified, exiting job."
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@v5
 
@@ -33,7 +38,14 @@ jobs:
         run: npm run test
 
       # Publish to npm
-      - name: Publish npm package
+      - name: Publish npm package (prerelease)
+        if: ${{ github.ref_type == 'tag' && contains(github.ref_name, 'beta') }}
+        run: npm publish --access public --tag pre
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+      - name: Publish npm package (regular)
+        if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, 'beta') }}
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -45,8 +45,8 @@ jobs:
       # Publish to npm
       - name: Publish npm package (prerelease)
         if: ${{ github.ref_type == 'tag' && contains(github.ref_name, 'beta') }}
-        run: npm publish --access public --tag pre
+        run: npm publish --dry-run --access public --tag pre
 
       - name: Publish npm package (regular)
         if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, 'beta') }}
-        run: npm publish --access public
+        run: npm publish --dry-run --access public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,10 @@ name: npm publish
 on:
   workflow_dispatch:
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,6 +26,7 @@ jobs:
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false  # never use caching in release builds
 
       # Install
       - name: Install
@@ -41,11 +46,7 @@ jobs:
       - name: Publish npm package (prerelease)
         if: ${{ github.ref_type == 'tag' && contains(github.ref_name, 'beta') }}
         run: npm publish --access public --tag pre
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Publish npm package (regular)
         if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, 'beta') }}
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -45,8 +45,8 @@ jobs:
       # Publish to npm
       - name: Publish npm package (prerelease)
         if: ${{ github.ref_type == 'tag' && contains(github.ref_name, 'beta') }}
-        run: npm publish --dry-run --access public --tag pre
+        run: npm publish --access public --tag pre
 
       - name: Publish npm package (regular)
         if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, 'beta') }}
-        run: npm publish --dry-run --access public
+        run: npm publish --access public

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -1,4 +1,4 @@
-name: Versioned release
+name: Tagged release
 
 on:
   workflow_dispatch:
@@ -19,6 +19,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
@@ -74,16 +77,6 @@ jobs:
         run: |
           echo "export default '${{env.NEW_VERSION}}';" > src/version.ts
 
-      # Build release assets
-      - name: Build release assets
-        run: |
-          npm run build
-
-      ## Add release assets
-      - name: Add release assets to commit
-        run: |
-          git add -f "dist/**/*"
-
       # Commit updated package.json
       - name: Commit package.json and create tag
         run: |
@@ -99,16 +92,3 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           git push origin && git push --tags
-
-      # Publish to npm
-      - name: Publish npm package (prerelease)
-        if: ${{ startsWith(github.event.inputs.release_type, 'pre') }}
-        run: npm publish --access public --tag pre
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-
-      - name: Publish npm package (regular)
-        if: ${{ !startsWith(github.event.inputs.release_type, 'pre') }}
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 .github
 CODE_OF_CONDUCT.md
+coverage
 dev
 node_modules
 src/**/*.html
-test

--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
   "license": "MIT",
   "scripts": {
     "build": "rm -rf ./dist; npx eslint && npx vite build && npx tsc && npm run sass && npm run sass-min && npm run svgsprite && npm run copyicons",
-    "prepack": "npm run test && npm run build",
+    "copyicons": "copyfiles -f ./src/images/documents/svg/*.svg ./dist/images/documents/svg",
+    "prepare": "npm run build",
+    "prepublishOnly": "vitest --run",
     "sass": "sass --style=expanded src/design-system.scss dist/css/design-system.css",
     "sass-min": "sass --style=compressed src/design-system.scss dist/css/design-system.min.css",
     "svgsprite": "node ./svg-sprite.mjs",
-    "copyicons": "copyfiles -f ./src/images/documents/svg/*.svg ./dist/images/documents/svg",
-    "test": "vitest",
-    "test:coverage": "vitest run --coverage",
+    "test": "vitest --run",
+    "test:coverage": "vitest --coverage",
     "tsc": "tsc"
   },
   "devDependencies": {


### PR DESCRIPTION
- split workflows into two distinct responsibilities: GH tag/release, and npm publish
- remove `npm run test` from `prepack` in package.json
- use `prepare` instead of `prepack` in package.json
- use `npm run test` in `prepublishOnly` in package.json
- tweak test tasks' 'watch' behaviour in package.json